### PR TITLE
Fix camera scanner visibility on home screen

### DIFF
--- a/src/screens/QuickScanScreen.js
+++ b/src/screens/QuickScanScreen.js
@@ -1,6 +1,6 @@
 // src/screens/QuickScanScreen.js
 import React, { useState } from 'react';
-import { View, Text, Button, StyleSheet, Modal, Alert } from 'react-native';
+import { View, Text, Button, StyleSheet, Alert } from 'react-native';
 import ScannerScreen from './ScannerScreen';
 import ProductForm from './ProductForm';
 import { getProductByBarcode } from '../db';
@@ -9,6 +9,10 @@ export default function QuickScanScreen({ onClose }) {
   const [scanOpen, setScanOpen] = useState(true);
   const [initial, setInitial] = useState(null);
   const [hasChanges, setHasChanges] = useState(false);
+
+  const closeAll = (changed = hasChanges) => {
+    onClose && onClose(changed);
+  };
 
   const openFormForBarcode = async (barcode) => {
     try {
@@ -30,19 +34,19 @@ export default function QuickScanScreen({ onClose }) {
 
   return (
     <View style={{ flex: 1, backgroundColor: '#fff' }}>
-      <View style={{ padding: 16 }}>
-        <Text style={styles.title}>Escanear (crear / editar)</Text>
-        <Text style={{ color: '#666', marginBottom: 8 }}>Apunta al código. Si existe lo editas; si no, lo creas.</Text>
-        <Button title="Cerrar" color="#666" onPress={() => onClose && onClose(hasChanges)} />
-      </View>
+      {!scanOpen && (
+        <View style={{ padding: 16 }}>
+          <Text style={styles.title}>Escanear (crear / editar)</Text>
+          <Text style={{ color: '#666', marginBottom: 8 }}>Apunta al código. Si existe lo editas; si no, lo creas.</Text>
+          <Button title="Cerrar" color="#666" onPress={() => closeAll()} />
+        </View>
+      )}
 
       {scanOpen && (
-        <Modal visible={scanOpen} animationType="fade" onRequestClose={() => setScanOpen(false)} transparent={false}>
-          <ScannerScreen
-            onClose={() => setScanOpen(false)}
-            onScanned={(scannedCode) => { setScanOpen(false); openFormForBarcode(scannedCode); }}
-          />
-        </Modal>
+        <ScannerScreen
+          onClose={() => closeAll()}
+          onScanned={(scannedCode) => { setScanOpen(false); openFormForBarcode(scannedCode); }}
+        />
       )}
 
       {!scanOpen && initial && (

--- a/src/screens/ScannerScreen.js
+++ b/src/screens/ScannerScreen.js
@@ -43,13 +43,14 @@ export default function ScannerScreen({ onClose, onScanned }) {
   return (
     <View style={{ flex:1, backgroundColor:'black' }}>
       <BarCodeScanner
-        style={{ flex:1 }}
+        style={StyleSheet.absoluteFillObject}
         onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
         // Puedes limitar tipos si deseas mayor precisión:
         // barCodeTypes={[BarCodeScanner.Constants.BarCodeType.ean13, BarCodeScanner.Constants.BarCodeType.ean8, BarCodeScanner.Constants.BarCodeType.code128]}
       />
+      <View style={styles.targetBox} pointerEvents="none" />
       <View style={styles.overlay}>
-        <Text style={styles.text}>{scanned ? 'Código escaneado' : 'Escanea un código'}</Text>
+        <Text style={styles.text}>{scanned ? 'Código escaneado' : 'Alinea el código dentro del marco'}</Text>
         {scanned && <Button title="Escanear otro" onPress={() => setScanned(false)} />}
         <Button title="Cerrar" onPress={onClose} />
       </View>
@@ -64,4 +65,14 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.55)', padding: 14, borderRadius: 12, gap: 10
   },
   text: { color: '#fff', textAlign: 'center', fontWeight: '600' },
+  targetBox: {
+    position: 'absolute',
+    top: '20%',
+    left: '10%',
+    right: '10%',
+    bottom: '30%',
+    borderWidth: 2,
+    borderColor: '#fff',
+    borderRadius: 12,
+  },
 });


### PR DESCRIPTION
## Summary
- Remove nested modal when scanning products and allow full-screen camera
- Expand barcode scanner to fill screen and show a target box with clearer instructions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf068e7b78832ca173e8b1e79b0c99