### PR TITLE
Enable realtime sale synchronization

### DIFF
--- a/App.js
+++ b/App.js
@@ -19,7 +19,7 @@ import FAB from './src/ui/FAB';
 import { theme } from './src/ui/Theme';
 
 // Sync cloud
-import { syncNow } from './src/sync';
+import { syncNow, initRealtimeSync } from './src/sync';
 
 export default function App() {
   const [ready, setReady] = useState(false);
@@ -43,6 +43,7 @@ export default function App() {
 
         // Auto-sync al iniciar (si hay internet)
         try { await syncNow(); await refresh(); } catch {}
+        initRealtimeSync();
       } catch {
         Alert.alert('Error', 'Fallo al inicializar la base de datos');
       }


### PR DESCRIPTION
## Summary
- listen for Supabase realtime events on products and sales
- record incoming sales locally and adjust inventory
- initialize realtime sync on app start

## Testing
- ⚠️ `npm test` (missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68bf74344a30832cb585191600da5e76