### PR TITLE
Add sync button to reports screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -211,6 +211,14 @@ export default function App() {
 
       {tab === 'reports' && (
         <View style={styles.content}>
+          <View style={styles.actionRow}>
+            <TouchableOpacity
+              style={[styles.secondaryBtn, { borderColor: '#111' }]}
+              onPress={manualSync}
+            >
+              <Text style={[styles.secondaryBtnText, { fontWeight: '800' }]}>🔄 Sync</Text>
+            </TouchableOpacity>
+          </View>
           <View style={styles.reportGrid}>
             <TouchableOpacity style={styles.reportCard} onPress={() => setOpenHistory(true)}>
               <Text style={styles.reportEmoji}>📈</Text>

--- a/src/db.js
+++ b/src/db.js
@@ -358,6 +358,16 @@ export function listRecentSales(limit=50){
     }, reject);
   });
 }
+
+export function getLastSaleTs(){
+  return new Promise(resolve=>{
+    db().transaction(tx=>{
+      tx.executeSql(`SELECT MAX(ts) as m FROM sales;`, [], (_,_r)=>{
+        resolve(_r.rows.item(0)?.m || 0);
+      });
+    });
+  });
+}
 export function listSalesBetween(fromTs,toTs){
   return new Promise((resolve,reject)=>{
     const params=[]; let where='WHERE COALESCE(voided,0)=0';

--- a/src/sync.js
+++ b/src/sync.js
@@ -5,7 +5,7 @@ import {
   getUnsyncedSales, markSaleSynced,
   upsertProductsBulk, upsertCategoriesBulk,
   listLocalProductsUpdatedAfter, listProducts, listCategories,
-  insertSaleFromCloud, insertOrUpdateProduct
+  insertSaleFromCloud, insertOrUpdateProduct, getLastSaleTs
 } from './db';
 
 const DEVICE_ID = `${Platform.OS}-v1`;
@@ -88,6 +88,41 @@ export async function pullProducts({ sinceTs } = {}) {
   if (!ec && cats?.length) await upsertCategoriesBulk(cats);
 }
 
+export async function pullSales({ sinceTs } = {}) {
+  const sinceIso = sinceTs ? new Date(sinceTs).toISOString() : '1970-01-01T00:00:00Z';
+
+  const { data: sales, error } = await supabase
+    .from('sales')
+    .select('*')
+    .gt('created_at', sinceIso)
+    .neq('device_id', DEVICE_ID)
+    .order('created_at', { ascending: true })
+    .limit(1000);
+  if (!error && sales?.length) {
+    for (const s of sales) {
+      let items = s.items || s.items_json || [];
+      if (typeof items === 'string') {
+        try { items = JSON.parse(items); } catch {}
+      }
+      try {
+        await insertSaleFromCloud({
+          ts: Date.parse(s.created_at || s.ts || new Date().toISOString()),
+          total: s.total,
+          payment_method: s.payment_method,
+          cash_received: s.cash_received,
+          change_given: s.change_given,
+          discount: s.discount,
+          tax: s.tax,
+          notes: s.notes,
+          items,
+        });
+      } catch (e) {
+        console.warn('pull sale error', e);
+      }
+    }
+  }
+}
+
 // ---------- SYNC PRINCIPAL ----------
 export async function syncNow() {
   // 1) Subir primero todo lo local
@@ -96,8 +131,10 @@ export async function syncNow() {
   await pushSales();
 
   // 2) Luego bajar lo más reciente
-  const lastLocal = await listLocalProductsUpdatedAfter();
-  await pullProducts({ sinceTs: lastLocal });
+  const lastProductTs = await listLocalProductsUpdatedAfter();
+  const lastSaleTs = await getLastSaleTs();
+  await pullProducts({ sinceTs: lastProductTs });
+  await pullSales({ sinceTs: lastSaleTs });
 }
 
 // ---------- REALTIME ----------


### PR DESCRIPTION
## Summary
- add manual sync button to reports tab to update inventory and sales data
- pull remote sales from Supabase during sync to show cross-device reports

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1b6f1bb78832c8ab5f637ba73dd8e