### PR TITLE
feat: refresh sales experience and product media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,20 +10,27 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "1.17.11",
         "@react-native-community/datetimepicker": "^6.7.3",
+        "@react-native-community/slider": "^4.5.7",
         "@react-native-picker/picker": "2.4.8",
         "@supabase/supabase-js": "^2.56.0",
         "expo": "~48.0.21",
         "expo-asset": "~8.9.1",
         "expo-barcode-scanner": "~12.3.2",
+        "expo-document-picker": "~11.2.1",
         "expo-file-system": "~15.2.2",
         "expo-haptics": "~12.2.1",
+        "expo-image-manipulator": "~11.1.1",
+        "expo-image-picker": "~14.1.1",
         "expo-sharing": "~11.2.2",
         "expo-splash-screen": "~0.18.2",
         "expo-sqlite": "~11.1.1",
         "expo-status-bar": "~1.4.4",
         "react": "18.2.0",
         "react-native": "0.71.14",
-        "react-native-url-polyfill": "^2.0.0"
+        "react-native-chart-kit": "^6.12.0",
+        "react-native-svg": "^13.4.0",
+        "react-native-url-polyfill": "^2.0.0",
+        "react-native-view-shot": "^3.8.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -3998,6 +4005,12 @@
         "invariant": "^2.2.4"
       }
     },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.7.tgz",
+      "integrity": "sha512-WMDDZjNF2Bd8M8TrSqKf5xhM9ikdfCHtSPur64Ow3bB/OVrKufUQZ59NmYdNZNeGPvcHHTsafuYTY8zfZfbchQ==",
+      "license": "MIT"
+    },
     "node_modules/@react-native-picker/picker": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.8.tgz",
@@ -4700,6 +4713,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4810,6 +4832,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
     },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
@@ -5536,6 +5564,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/dag-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
@@ -5799,6 +5886,61 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5853,6 +5995,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -6232,6 +6386,15 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-document-picker": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-11.2.2.tgz",
+      "integrity": "sha512-EeonRKxkK9E20LEAh93IvlwFjNkUCJKnhBEama9PmIDYWW7RyANZ8eP9C2PupThTDbivzRDNp7Ec7dIeyDAWjw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "15.2.2",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-15.2.2.tgz",
@@ -6270,6 +6433,30 @@
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.1.1.tgz",
       "integrity": "sha512-ciEHVokU0f6w0eTxdRxLCio6tskMsjxWIoV92+/ZD37qePUJYMfEphPhu1sruyvMBNR8/j5iyOvPFVGTfO8oxA==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-11.1.1.tgz",
+      "integrity": "sha512-W9LfJK/IL7EhhkkC1JQnEX/1S9B09rcGasJiQjXc2s1bEsrQnqXvXEv7shUW8b/L8rE+ynf+XvvDE+YIDL7oFg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-14.1.1.tgz",
+      "integrity": "sha512-SvWtnkLW7jp5Ntvk3lVcRQmhFYja8psmiR7O6P/+7S6f4llt3vaFwb4I3+pUXqJxxpi7BHc2+95qOLf0SFOIag==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.1.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -7185,6 +7372,19 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -8722,6 +8922,12 @@
       "integrity": "sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ==",
       "license": "MIT"
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -9897,6 +10103,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nullthrows": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
@@ -10334,6 +10552,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/paths-js": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/paths-js/-/paths-js-0.4.11.tgz",
+      "integrity": "sha512-3mqcLomDBXOo7Fo+UlaenG6f71bk1ZezPQy2JCmYHy2W2k5VKpP+Jbin9H0bjXynelTbglCqdFhSEkeIkKTYUA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.11.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10538,6 +10765,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -10849,6 +11082,22 @@
         "react": "18.2.0"
       }
     },
+    "node_modules/react-native-chart-kit": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-6.12.0.tgz",
+      "integrity": "sha512-nZLGyCFzZ7zmX0KjYeeSV1HKuPhl1wOMlTAqa0JhlyW62qV/1ZPXHgT8o9s8mkFaGxdqbspOeuaa6I9jUQDgnA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.13",
+        "paths-js": "^0.4.10",
+        "point-in-polygon": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": "> 16.7.0",
+        "react-native": ">= 0.50.0",
+        "react-native-svg": "> 6.4.1"
+      }
+    },
     "node_modules/react-native-codegen": {
       "version": "0.71.6",
       "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.71.6.tgz",
@@ -10867,6 +11116,20 @@
       "integrity": "sha512-1dVk9NwhoyKHCSxcrM6vY6cxmojeATsBobDicX0ZKr7DgUF2cBQRTKsimQFvzH8XhOVXyH8p4HyDSZNIFI8OlQ==",
       "license": "MIT"
     },
+    "node_modules/react-native-svg": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-13.4.0.tgz",
+      "integrity": "sha512-B3TwK+H0+JuRhYPzF21AgqMt4fjhCwDZ9QUtwNstT5XcslJBXC0FoTkdZo8IEb1Sv4suSqhZwlAY6lwOv3tHag==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-url-polyfill": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
@@ -10876,6 +11139,19 @@
         "whatwg-url-without-unicode": "8.0.0-3"
       },
       "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-view-shot": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-3.8.0.tgz",
+      "integrity": "sha512-4cU8SOhMn3YQIrskh+5Q8VvVRxQOu8/s1M9NAL4z5BY1Rm0HXMWkQJ4N0XsZ42+Yca+y86ISF3LC5qdLPvPuiA==",
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*",
         "react-native": "*"
       }
     },
@@ -12444,6 +12720,15 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -12929,6 +13214,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -16,20 +16,27 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-native-community/datetimepicker": "^6.7.3",
+    "@react-native-community/slider": "^4.5.7",
     "@react-native-picker/picker": "2.4.8",
     "@supabase/supabase-js": "^2.56.0",
     "expo": "~48.0.21",
     "expo-asset": "~8.9.1",
     "expo-barcode-scanner": "~12.3.2",
+    "expo-document-picker": "~11.2.1",
     "expo-file-system": "~15.2.2",
     "expo-haptics": "~12.2.1",
+    "expo-image-manipulator": "~11.1.1",
+    "expo-image-picker": "~14.1.1",
     "expo-sharing": "~11.2.2",
     "expo-splash-screen": "~0.18.2",
     "expo-sqlite": "~11.1.1",
     "expo-status-bar": "~1.4.4",
     "react": "18.2.0",
     "react-native": "0.71.14",
-    "react-native-url-polyfill": "^2.0.0"
+    "react-native-chart-kit": "^6.12.0",
+    "react-native-svg": "^13.4.0",
+    "react-native-url-polyfill": "^2.0.0",
+    "react-native-view-shot": "^3.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/src/db.js
+++ b/src/db.js
@@ -78,6 +78,13 @@ function migrateProductsWeight(tx, done){
   }, ()=>{ done&&done(); return true; });
 }
 
+function migrateProductImages(tx, done){
+  const cols = [
+    { name: 'image_uri', def: 'TEXT' },
+  ];
+  ensureColumnsInTable(tx, 'products', cols, ()=> done && done());
+}
+
 function migrateSaleItemsQty(tx, done){
   tx.executeSql(`PRAGMA table_info(sale_items);`, [], (_,_r)=>{
     let qtyType='REAL';
@@ -107,6 +114,16 @@ function migrateSaleItemsQty(tx, done){
   }, ()=>{ done&&done(); return true; });
 }
 
+function migrateSaleTransferProof(tx, done){
+  const cols = [
+    { name: 'transfer_receipt_uri', def: 'TEXT' },
+    { name: 'transfer_receipt_name', def: 'TEXT' },
+  ];
+  ensureColumnsInTable(tx, 'sales', cols, ()=>
+    ensureColumnsInTable(tx, 'sale', cols, ()=> done && done())
+  );
+}
+
 // ---------- INIT ----------
 export function initDB(){
   return new Promise((resolve,reject)=>{
@@ -123,6 +140,7 @@ export function initDB(){
         expiry_date TEXT,
         stock REAL DEFAULT 0,
         sold_by_weight INTEGER DEFAULT 0,
+        image_uri TEXT,
         updated_at INTEGER
       );`);
       tx.executeSql(`CREATE INDEX IF NOT EXISTS idx_products_barcode ON products(barcode);`);
@@ -145,6 +163,8 @@ export function initDB(){
         discount REAL DEFAULT 0,
         tax REAL DEFAULT 0,
         notes TEXT,
+        transfer_receipt_uri TEXT,
+        transfer_receipt_name TEXT,
         voided INTEGER DEFAULT 0
       );`);
       tx.executeSql(`CREATE TABLE IF NOT EXISTS sale_items(
@@ -162,7 +182,9 @@ export function initDB(){
       tx.executeSql(`CREATE TABLE IF NOT EXISTS sale(
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         ts INTEGER NOT NULL,
-        total REAL NOT NULL
+        total REAL NOT NULL,
+        transfer_receipt_uri TEXT,
+        transfer_receipt_name TEXT
       );`);
 
       // templates (legacy, si existe tu editor)
@@ -181,6 +203,8 @@ export function initDB(){
       migrateCloudOutbox(tx, ()=>{});
       migrateProductsWeight(tx, ()=>{});
       migrateSaleItemsQty(tx, ()=>{});
+      migrateProductImages(tx, ()=>{});
+      migrateSaleTransferProof(tx, ()=>{});
     }, reject, ()=>resolve(true));
   });
 }
@@ -195,19 +219,20 @@ export function insertOrUpdateProduct(p){
     sale_price:Number(p.salePrice ?? p.sale_price ?? 0)||0,
     expiry_date:p.expiryDate ?? p.expiry_date ?? null,
     stock:Number(p.stock ?? 0)||0,
-    sold_by_weight:Number(p.sold_by_weight ?? p.soldByWeight ?? 0)||0
+    sold_by_weight:Number(p.sold_by_weight ?? p.soldByWeight ?? 0)||0,
+    image_uri:p.imageUri ?? p.image_uri ?? null,
   };
   if(!payload.barcode) return Promise.reject(new Error('barcode requerido'));
   return new Promise((resolve,reject)=>{
     db().transaction((tx)=>{
       tx.executeSql(
-        `INSERT INTO products (barcode,name,category,purchase_price,sale_price,expiry_date,stock,sold_by_weight,updated_at)
-         VALUES (?,?,?,?,?,?,?,?,?)
+        `INSERT INTO products (barcode,name,category,purchase_price,sale_price,expiry_date,stock,sold_by_weight,image_uri,updated_at)
+         VALUES (?,?,?,?,?,?,?,?,?,?)
          ON CONFLICT(barcode) DO UPDATE SET
            name=excluded.name, category=excluded.category,
            purchase_price=excluded.purchase_price, sale_price=excluded.sale_price,
-           expiry_date=excluded.expiry_date, stock=excluded.stock, sold_by_weight=excluded.sold_by_weight, updated_at=excluded.updated_at;`,
-        [payload.barcode,payload.name,payload.category,payload.purchase_price,payload.sale_price,payload.expiry_date,payload.stock,payload.sold_by_weight,now]
+           expiry_date=excluded.expiry_date, stock=excluded.stock, sold_by_weight=excluded.sold_by_weight, image_uri=excluded.image_uri, updated_at=excluded.updated_at;`,
+        [payload.barcode,payload.name,payload.category,payload.purchase_price,payload.sale_price,payload.expiry_date,payload.stock,payload.sold_by_weight,payload.image_uri,now]
       );
     }, reject, ()=>resolve(true));
   });
@@ -219,13 +244,13 @@ export function upsertProductsBulk(list){
     db().transaction((tx)=>{
       (list||[]).forEach(p=>{
         tx.executeSql(
-          `INSERT INTO products (barcode,name,category,purchase_price,sale_price,expiry_date,stock,sold_by_weight,updated_at)
-           VALUES (?,?,?,?,?,?,?,?,?)
+          `INSERT INTO products (barcode,name,category,purchase_price,sale_price,expiry_date,stock,sold_by_weight,image_uri,updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(barcode) DO UPDATE SET
             name=excluded.name, category=excluded.category,
             purchase_price=excluded.purchase_price, sale_price=excluded.sale_price,
-            expiry_date=excluded.expiry_date, stock=excluded.stock, sold_by_weight=excluded.sold_by_weight, updated_at=?;`,
-          [p.barcode, p.name, p.category, p.purchase_price||0, p.sale_price||0, p.expiry_date||null, p.stock||0, p.sold_by_weight||0, now, now]
+            expiry_date=excluded.expiry_date, stock=excluded.stock, sold_by_weight=excluded.sold_by_weight, image_uri=excluded.image_uri, updated_at=?;`,
+          [p.barcode, p.name, p.category, p.purchase_price||0, p.sale_price||0, p.expiry_date||null, p.stock||0, p.sold_by_weight||0, p.image_uri ?? p.imageUri ?? null, now, now]
         );
       });
     }, reject, ()=>resolve(true));
@@ -280,7 +305,8 @@ export function exportAllProductsOrdered(){
         `SELECT barcode, barcode AS id, IFNULL(name,'') AS name, IFNULL(category,'') AS category,
                 IFNULL(purchase_price,0) AS purchasePrice, IFNULL(sale_price,0) AS salePrice,
                 IFNULL(expiry_date,'') AS expiryDate, IFNULL(stock,0) AS stock,
-                IFNULL(sold_by_weight,0) AS soldByWeight
+                IFNULL(sold_by_weight,0) AS soldByWeight,
+                IFNULL(image_uri,'') AS imageUri
          FROM products ORDER BY name ASC, id DESC;`,
         [], (_,_r)=>resolve(rowsToArray(_r))
       );
@@ -316,6 +342,8 @@ export function recordSale(cart, opts = {}){
   const cashReceived = Number(opts.amountPaid||0)||0;
   const change = Math.max(0, cashReceived - total);
   const notes = opts.note || null;
+  const transferUri = opts.transferReceiptUri || null;
+  const transferName = opts.transferReceiptName || null;
 
   const clientSaleId = `local-${ts}-${Math.random().toString(36).slice(2,8)}`;
 
@@ -323,9 +351,9 @@ export function recordSale(cart, opts = {}){
     let firstError=null;
     db().transaction((tx)=>{
       tx.executeSql(
-        `INSERT INTO sales (ts,total,payment_method,cash_received,change_given,discount,tax,notes,voided)
-         VALUES (?,?,?,?,?,?,?, ?, 0);`,
-        [ts,total,payment,cashReceived,change,discount,tax,notes],
+        `INSERT INTO sales (ts,total,payment_method,cash_received,change_given,discount,tax,notes,transfer_receipt_uri,transfer_receipt_name,voided)
+         VALUES (?,?,?,?,?,?,?,?,?,?,0);`,
+        [ts,total,payment,cashReceived,change,discount,tax,notes,transferUri,transferName],
         (_insert,res)=>{
           const saleId = res.insertId;
 
@@ -353,8 +381,17 @@ export function recordSale(cart, opts = {}){
 
           // Encolar para sync
           const payload = {
-            total, payment_method:payment, cash_received:cashReceived, change_given:change,
-            discount, tax, notes, client_sale_id: clientSaleId, items: itemsJson
+            total,
+            payment_method:payment,
+            cash_received:cashReceived,
+            change_given:change,
+            discount,
+            tax,
+            notes,
+            transfer_receipt_uri: transferUri,
+            transfer_receipt_name: transferName,
+            client_sale_id: clientSaleId,
+            items: itemsJson
           };
           tx.executeSql(
             `INSERT OR IGNORE INTO outbox_sales (local_sale_id, client_sale_id, payload_json, synced, created_at)
@@ -380,6 +417,8 @@ export function insertSaleFromCloud(payload){
   const discount = Number(payload?.discount || 0) || 0;
   const tax = Number(payload?.tax || 0) || 0;
   const notes = payload?.notes || null;
+  const transferUri = payload?.transfer_receipt_uri ?? payload?.transferReceiptUri ?? null;
+  const transferName = payload?.transfer_receipt_name ?? payload?.transferReceiptName ?? null;
 
   return new Promise((resolve,reject)=>{
     let firstError=null;
@@ -397,9 +436,9 @@ export function insertSaleFromCloud(payload){
           
           // No existe, proceder con la inserción
           tx.executeSql(
-            `INSERT INTO sales (ts,total,payment_method,cash_received,change_given,discount,tax,notes,voided)
-             VALUES (?,?,?,?,?,?,?, ?, 0);`,
-            [ts,total,payment,cashReceived,change,discount,tax,notes],
+            `INSERT INTO sales (ts,total,payment_method,cash_received,change_given,discount,tax,notes,transfer_receipt_uri,transfer_receipt_name,voided)
+             VALUES (?,?,?,?,?,?,?,?,?,?,0);`,
+            [ts,total,payment,cashReceived,change,discount,tax,notes,transferUri,transferName],
             (_insert,res)=>{
               const saleId = res.insertId;
               console.log(`✅ Venta desde cloud insertada: saleId=${saleId}, ts=${ts}, total=${total}`);
@@ -459,7 +498,7 @@ export function listSalesBetween(fromTs,toTs){
     if(typeof fromTs==='number'){ where+=' AND ts >= ?'; params.push(fromTs); }
     if(typeof toTs==='number'){ where+=' AND ts <= ?'; params.push(toTs); }
     db().transaction((tx)=>{
-      tx.executeSql(`SELECT id,ts,total,payment_method,cash_received,change_given,discount,tax,voided FROM sales ${where} ORDER BY ts DESC;`,
+      tx.executeSql(`SELECT id,ts,total,payment_method,cash_received,change_given,discount,tax,voided,transfer_receipt_uri,transfer_receipt_name FROM sales ${where} ORDER BY ts DESC;`,
         params, (_,_r)=>resolve(rowsToArray(_r)));
     }, reject);
   });
@@ -536,7 +575,8 @@ export function getUnsyncedSales(){
     db().transaction((tx)=>{
       tx.executeSql(
         `SELECT o.id as outbox_id, o.local_sale_id, o.client_sale_id, o.payload_json,
-                s.total, s.payment_method, s.cash_received, s.change_given, s.discount, s.tax, s.notes
+                s.total, s.payment_method, s.cash_received, s.change_given, s.discount, s.tax, s.notes,
+                s.transfer_receipt_uri, s.transfer_receipt_name
            FROM outbox_sales o
            JOIN sales s ON s.id=o.local_sale_id
           WHERE o.synced=0
@@ -554,7 +594,9 @@ export function getUnsyncedSales(){
             change_given: r.change_given,
             discount: r.discount,
             tax: r.tax,
-            notes: r.notes
+            notes: r.notes,
+            transfer_receipt_uri: r.transfer_receipt_uri,
+            transfer_receipt_name: r.transfer_receipt_name
           }));
           resolve(list);
         }

--- a/src/screens/SalesDashboardScreen.js
+++ b/src/screens/SalesDashboardScreen.js
@@ -1,8 +1,19 @@
 // src/screens/SalesDashboardScreen.js
 import React, { useEffect, useMemo, useState } from 'react';
-import { View, Text, SafeAreaView, StyleSheet, TouchableOpacity, ActivityIndicator, ScrollView, Button, Alert } from 'react-native';
+import {
+  View,
+  Text,
+  SafeAreaView,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  Button,
+  Alert,
+  useWindowDimensions,
+} from 'react-native';
+import { LineChart } from 'react-native-chart-kit';
 import { getSalesSeries } from '../db';
-import { theme } from '../ui/Theme';
 
 function startOfDay(d){ const x=new Date(d); x.setHours(0,0,0,0); return x; }
 function addDays(d,n){ const x=new Date(d); x.setDate(x.getDate()+n); return x; }
@@ -12,11 +23,14 @@ export default function SalesDashboardScreen({ onClose, refreshKey }){
   const [mode, setMode] = useState('7d'); // '7d' | '30d' | '12m'
   const [loading, setLoading] = useState(false);
   const [series, setSeries] = useState([]);
+  const [activePoint, setActivePoint] = useState(null);
+
+  const { width } = useWindowDimensions();
 
   const range = useMemo(()=>{
     const now = new Date();
     if (mode==='7d'){ const to=addDays(startOfDay(now),1)-1; const from=addDays(startOfDay(now),-6).getTime(); return { from, to, gran:'day' }; }
-    if (mode==='30d'){ const to=addDays(startOfDay(now),1)-1; const from=addDays(startOfDay(now),-29).getTime(); return { from, to, gran:'day' }; }
+    if (mode==='30d'){ const to=addDays(startOfDay(now),1)-1; const from=addDays(startOfDay(now),-29).getTime(); return { from,to, gran:'day' }; }
     const first = new Date(now.getFullYear(), now.getMonth(), 1);
     const from = addMonths(first, -11).getTime();
     const to = addDays(addMonths(first,1), -1).getTime();
@@ -29,12 +43,50 @@ export default function SalesDashboardScreen({ onClose, refreshKey }){
         setLoading(true);
         const rows = await getSalesSeries(range.from, range.to, range.gran);
         setSeries(rows);
+        setActivePoint(null);
       }catch(e){ Alert.alert('Error','No se pudo cargar el dashboard.'); }
       finally{ setLoading(false); }
     })();
   }, [range.from, range.to, range.gran, refreshKey]);
 
-  const max = Math.max(1, ...series.map(r => Number(r.total||0)));
+  const chartData = useMemo(() => {
+    const labels = series.map((r) => {
+      if (range.gran === 'month') return r.bucket;
+      return String(r.bucket).slice(5);
+    });
+    const data = series.map((r) => Number(r.total || 0));
+    return {
+      labels,
+      datasets: [
+        {
+          data,
+          color: () => '#2a6cc5',
+          strokeWidth: 3,
+        },
+      ],
+    };
+  }, [series, range.gran]);
+
+  const stats = useMemo(() => {
+    if (!series.length) return { total: 0, avg: 0, best: 0 };
+    const total = series.reduce((sum, item) => sum + Number(item.total || 0), 0);
+    const best = Math.max(...series.map((item) => Number(item.total || 0)));
+    const avg = total / series.length;
+    return { total, avg, best };
+  }, [series]);
+
+  const chartWidth = Math.max(width - 32, Math.max(series.length * 70, width * 0.9));
+  const chartConfig = useMemo(() => ({
+    backgroundColor: '#fff',
+    backgroundGradientFrom: '#f4f7ff',
+    backgroundGradientTo: '#ecf2ff',
+    decimalPlaces: 0,
+    color: (opacity = 1) => `rgba(33, 111, 237, ${opacity})`,
+    labelColor: (opacity = 1) => `rgba(80, 80, 80, ${opacity})`,
+    propsForDots: { r: '5', strokeWidth: '2', stroke: '#ffffff' },
+    propsForBackgroundLines: { strokeDasharray: '', stroke: '#dfe6ff' },
+  }), []);
+
   return (
     <SafeAreaView style={{ flex:1, backgroundColor:'#fff' }}>
       <View style={{ padding:16, flex:1 }}>
@@ -46,23 +98,56 @@ export default function SalesDashboardScreen({ onClose, refreshKey }){
           ))}
         </View>
 
-        {loading ? <ActivityIndicator/> : (
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.chartWrap}>
-            <View style={styles.chart}>
-              {series.map((r, idx)=> {
-                const h = Math.max(4, Math.round((Number(r.total||0)/max)*180));
-                return (
-                  <View key={idx} style={styles.barWrap}>
-                    <View style={[styles.bar, { height: h }]} />
-                    <Text style={styles.barLabel}>{r.bucket}</Text>
-                    <Text style={styles.barVal}>${Number(r.total||0).toFixed(0)}</Text>
-                  </View>
-                );
-              })}
-              {!series.length && <Text style={{ color:'#888' }}>Sin datos</Text>}
-            </View>
-          </ScrollView>
+        {loading ? (
+          <ActivityIndicator />
+        ) : (
+          <View style={styles.chartCard}>
+            {series.length ? (
+              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                <LineChart
+                  data={chartData}
+                  width={chartWidth}
+                  height={220}
+                  chartConfig={chartConfig}
+                  bezier
+                  fromZero
+                  style={styles.chart}
+                  segments={4}
+                  onDataPointClick={({ value, index }) => {
+                    const bucket = series[index];
+                    setActivePoint({ value, bucket });
+                  }}
+                />
+              </ScrollView>
+            ) : (
+              <Text style={{ color:'#888', textAlign:'center', paddingVertical:20 }}>Sin datos en el rango seleccionado.</Text>
+            )}
+          </View>
         )}
+
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryTitle}>Resumen</Text>
+          <View style={styles.summaryRow}>
+            <View style={styles.summaryItem}>
+              <Text style={styles.summaryLabel}>Total</Text>
+              <Text style={styles.summaryValue}>${stats.total.toFixed(0)}</Text>
+            </View>
+            <View style={styles.summaryItem}>
+              <Text style={styles.summaryLabel}>Promedio</Text>
+              <Text style={styles.summaryValue}>${stats.avg.toFixed(0)}</Text>
+            </View>
+            <View style={styles.summaryItem}>
+              <Text style={styles.summaryLabel}>Mejor jornada</Text>
+              <Text style={styles.summaryValue}>${stats.best.toFixed(0)}</Text>
+            </View>
+          </View>
+          {activePoint && (
+            <View style={styles.highlight}>
+              <Text style={{ fontWeight:'700' }}>{activePoint.bucket?.bucket}</Text>
+              <Text style={{ color:'#555' }}>Total: ${Number(activePoint.value).toFixed(0)}</Text>
+            </View>
+          )}
+        </View>
 
         <View style={{ marginTop:8 }}>
           <Button title="Cerrar" color="#666" onPress={onClose} />
@@ -76,10 +161,13 @@ const styles = StyleSheet.create({
   row:{ flexDirection:'row', gap:8, marginBottom:8 },
   pill:{ borderWidth:1, borderColor:'#ccc', borderRadius:999, paddingHorizontal:12, paddingVertical:6, backgroundColor:'#fff' },
   pillOn:{ backgroundColor:'#111', borderColor:'#111' },
-  chartWrap:{ flex:1 },
-  chart:{ flexDirection:'row', alignItems:'flex-end', gap:12, paddingVertical:10, minHeight:220 },
-  barWrap:{ alignItems:'center' },
-  bar:{ width:18, backgroundColor:'#2a6', borderRadius:6 },
-  barLabel:{ fontSize:10, color:'#555', marginTop:4 },
-  barVal:{ fontSize:10, color:'#333' },
+  chartCard:{ borderWidth:1, borderColor:'#e2e6f5', borderRadius:16, padding:12, backgroundColor:'#fff', minHeight:240, marginBottom:12 },
+  chart:{ borderRadius:12 },
+  summaryCard:{ borderWidth:1, borderColor:'#e6e6e6', borderRadius:16, padding:16, backgroundColor:'#fafafa', gap:12 },
+  summaryTitle:{ fontSize:16, fontWeight:'700' },
+  summaryRow:{ flexDirection:'row', gap:12 },
+  summaryItem:{ flex:1, borderRadius:12, backgroundColor:'#fff', padding:12, borderWidth:1, borderColor:'#eee' },
+  summaryLabel:{ color:'#666', fontSize:12 },
+  summaryValue:{ fontWeight:'700', fontSize:16 },
+  highlight:{ borderRadius:12, borderWidth:1, borderColor:'#d6e4ff', backgroundColor:'#eef3ff', padding:12 },
 });

--- a/src/screens/SellScreen.js
+++ b/src/screens/SellScreen.js
@@ -1,13 +1,40 @@
 // src/screens/SellScreen.js
-import React, { useMemo, useState } from 'react';
-import { View, Text, StyleSheet, TextInput, TouchableOpacity, FlatList, Alert, Platform, KeyboardAvoidingView, Modal } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+  Alert,
+  Platform,
+  KeyboardAvoidingView,
+  Modal,
+  Image,
+  useWindowDimensions,
+} from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+
 import ScannerScreen from './ScannerScreen';
 import { getProductByBarcode, recordSale } from '../db';
 import { theme } from '../ui/Theme';
+import { copyFileToDocuments, getFileDisplayName } from '../utils/media';
 
 const PMETHODS = ['efectivo', 'debito', 'credito', 'transferencia'];
 
-export default function SellScreen({ onClose, onSold }) {
+export default function SellScreen({
+  onClose,
+  onSold,
+  onRequestCreateProduct,
+  pendingBarcode,
+  recentlyCreatedBarcode,
+  onConsumeRecentBarcode,
+}) {
+  const { width } = useWindowDimensions();
+  const isCompact = width < 380;
+
   const [scannerOpen, setScannerOpen] = useState(false);
   const [barcodeManual, setBarcodeManual] = useState('');
   const [cart, setCart] = useState([]); // {barcode,name,unit_price,qty,sold_by_weight}
@@ -15,82 +42,251 @@ export default function SellScreen({ onClose, onSold }) {
   const [amountPaid, setAmountPaid] = useState('');
   const [weightProd, setWeightProd] = useState(null);
   const [weightQty, setWeightQty] = useState('');
+  const [transferProof, setTransferProof] = useState(null); // { uri, name, kind }
+  const [previewUri, setPreviewUri] = useState(null);
 
-  const total = useMemo(() => cart.reduce((a, it) => a + (Number(it.qty || 0) * Number(it.unit_price || 0)), 0), [cart]);
+  const total = useMemo(
+    () => cart.reduce((a, it) => a + (Number(it.qty || 0) * Number(it.unit_price || 0)), 0),
+    [cart]
+  );
   const change = Math.max(0, Number(amountPaid || 0) - total);
   const canPay = total > 0 && (method !== 'efectivo' || Number(amountPaid || 0) >= total);
 
-  const addOrInc = (p) => {
-    setCart(prev => {
-      const i = prev.findIndex(x => x.barcode === p.barcode);
+  const addOrInc = useCallback((p) => {
+    setCart((prev) => {
+      const i = prev.findIndex((x) => x.barcode === p.barcode);
       if (i >= 0) {
         const next = [...prev];
-        next[i] = { ...next[i], qty: Number(next[i].qty || 0) + 1, unit_price: p.sale_price ?? next[i].unit_price };
+        next[i] = {
+          ...next[i],
+          qty: Number(next[i].qty || 0) + 1,
+          unit_price: p.sale_price ?? next[i].unit_price,
+        };
         return next;
       }
-      return [...prev, { barcode: p.barcode, name: p.name || '', unit_price: Number(p.sale_price || 0), qty: 1, sold_by_weight: p.sold_by_weight ? 1 : 0 }];
+      return [
+        ...prev,
+        {
+          barcode: p.barcode,
+          name: p.name || '',
+          unit_price: Number(p.sale_price || 0),
+          qty: 1,
+          sold_by_weight: p.sold_by_weight ? 1 : 0,
+        },
+      ];
     });
-  };
+  }, []);
 
-  const addProduct = (p) => {
-    if (p.sold_by_weight) {
-      setWeightProd(p);
-      setWeightQty('');
-    } else {
-      addOrInc(p);
-    }
-  };
+  const addProduct = useCallback(
+    (p) => {
+      if (p.sold_by_weight) {
+        setWeightProd(p);
+        setWeightQty('');
+      } else {
+        addOrInc(p);
+      }
+    },
+    [addOrInc]
+  );
 
-  const scanDone = async (code) => {
-    setScannerOpen(false);
-    const p = await getProductByBarcode(String(code).trim());
-    if (!p) return Alert.alert('No encontrado', 'Ese código no existe en inventario.');
-    addProduct(p);
-  };
+  const handleMissingProduct = useCallback(
+    (code) => {
+      Alert.alert('Producto no encontrado', 'Ese código no existe en inventario.', [
+        { text: 'Continuar sin agregar', style: 'cancel' },
+        {
+          text: 'Agregar producto',
+          onPress: () => onRequestCreateProduct && onRequestCreateProduct(String(code)),
+        },
+      ]);
+    },
+    [onRequestCreateProduct]
+  );
 
-  const addManual = async () => {
+  const scanDone = useCallback(
+    async (code) => {
+      setScannerOpen(false);
+      const trimmed = String(code).trim();
+      const p = await getProductByBarcode(trimmed);
+      if (!p) {
+        handleMissingProduct(trimmed);
+        return;
+      }
+      addProduct(p);
+    },
+    [addProduct, handleMissingProduct]
+  );
+
+  const addManual = useCallback(async () => {
     const code = (barcodeManual || '').trim();
     if (!code) return;
     setBarcodeManual('');
     const p = await getProductByBarcode(code);
-    if (!p) return Alert.alert('No encontrado', 'Ese código no existe en inventario.');
-    addProduct(p);
-  };
-  const inc = (b) => setCart(prev => prev.map(it => {
-    if (it.barcode !== b) return it;
-    const step = it.sold_by_weight ? 0.1 : 1;
-    return { ...it, qty: Number(it.qty) + step };
-  }));
-  const dec = (b) => setCart(prev => prev.map(it => {
-    if (it.barcode !== b) return it;
-    const step = it.sold_by_weight ? 0.1 : 1;
-    return { ...it, qty: Math.max(step, Number(it.qty) - step) };
-  }));
-  const removeItem = (b) => setCart(prev => prev.filter(it => it.barcode !== b));
-  const clear = () => setCart([]);
-
-  const pay = async () => {
-    if (!canPay) {
-      return Alert.alert('Monto insuficiente', 'El monto ingresado es menor al total.');
+    if (!p) {
+      handleMissingProduct(code);
+      return;
     }
+    addProduct(p);
+  }, [addProduct, barcodeManual, handleMissingProduct]);
+
+  const inc = useCallback((b) => {
+    setCart((prev) =>
+      prev.map((it) => {
+        if (it.barcode !== b) return it;
+        const step = it.sold_by_weight ? 0.1 : 1;
+        return { ...it, qty: Number(it.qty) + step };
+      })
+    );
+  }, []);
+
+  const dec = useCallback((b) => {
+    setCart((prev) =>
+      prev.map((it) => {
+        if (it.barcode !== b) return it;
+        const step = it.sold_by_weight ? 0.1 : 1;
+        return { ...it, qty: Math.max(step, Number(it.qty) - step) };
+      })
+    );
+  }, []);
+
+  const removeItem = useCallback((b) => {
+    setCart((prev) => prev.filter((it) => it.barcode !== b));
+  }, []);
+
+  const clear = useCallback(() => {
+    setCart([]);
+    setAmountPaid('');
+    setTransferProof(null);
+  }, []);
+
+  const attachProofFromCamera = useCallback(async () => {
     try {
-      const payload = { paymentMethod: method, amountPaid: Number(amountPaid || 0) };
+      const perm = await ImagePicker.requestCameraPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert('Permiso requerido', 'Activa el acceso a la cámara para tomar una foto del comprobante.');
+        return;
+      }
+      const result = await ImagePicker.launchCameraAsync({ quality: 0.7, allowsEditing: true });
+      if (result.canceled) return;
+      const asset = result.assets?.[0];
+      if (!asset?.uri) return;
+      const saved = await copyFileToDocuments(asset.uri, {
+        folder: 'receipts',
+        prefix: 'transfer',
+        extension: 'jpg',
+      });
+      setTransferProof({ uri: saved, name: asset.fileName || getFileDisplayName(saved), kind: 'image' });
+    } catch (e) {
+      console.warn('attachProofFromCamera error', e);
+      Alert.alert('Error', 'No se pudo capturar la imagen.');
+    }
+  }, []);
+
+  const attachProofFromLibrary = useCallback(async () => {
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({ quality: 0.8, allowsEditing: true, mediaTypes: ImagePicker.MediaTypeOptions.Images });
+      if (result.canceled) return;
+      const asset = result.assets?.[0];
+      if (!asset?.uri) return;
+      const saved = await copyFileToDocuments(asset.uri, {
+        folder: 'receipts',
+        prefix: 'transfer',
+        extension: 'jpg',
+      });
+      setTransferProof({ uri: saved, name: asset.fileName || getFileDisplayName(saved), kind: 'image' });
+    } catch (e) {
+      console.warn('attachProofFromLibrary error', e);
+      Alert.alert('Error', 'No se pudo adjuntar desde la galería.');
+    }
+  }, []);
+
+  const attachProofFromFile = useCallback(async () => {
+    try {
+      const result = await DocumentPicker.getDocumentAsync({ copyToCacheDirectory: true });
+      if (result.type === 'cancel') return;
+      const saved = await copyFileToDocuments(result.uri, {
+        folder: 'receipts',
+        prefix: 'transfer',
+      });
+      const isImage = String(result.mimeType || '').startsWith('image/');
+      setTransferProof({ uri: saved, name: result.name || getFileDisplayName(saved), kind: isImage ? 'image' : 'file' });
+    } catch (e) {
+      console.warn('attachProofFromFile error', e);
+      Alert.alert('Error', 'No se pudo adjuntar el archivo.');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!recentlyCreatedBarcode || !pendingBarcode) return;
+    if (recentlyCreatedBarcode !== pendingBarcode) return;
+
+    (async () => {
+      const product = await getProductByBarcode(recentlyCreatedBarcode);
+      if (product) {
+        addProduct(product);
+      } else {
+        Alert.alert('Producto', 'El nuevo producto aún no está disponible. Intenta nuevamente.');
+      }
+      onConsumeRecentBarcode && onConsumeRecentBarcode();
+    })();
+  }, [addProduct, onConsumeRecentBarcode, pendingBarcode, recentlyCreatedBarcode]);
+
+  const pay = useCallback(async () => {
+    if (!canPay) {
+      Alert.alert('Monto insuficiente', 'El monto ingresado es menor al total.');
+      return;
+    }
+    const proof = method === 'transferencia' ? transferProof : null;
+    try {
+      const payload = {
+        paymentMethod: method,
+        amountPaid: Number(amountPaid || 0),
+        transferReceiptUri: proof?.uri || null,
+        transferReceiptName: proof?.name || null,
+      };
       await recordSale(cart, payload);
-      Alert.alert('Venta registrada', `Total: $${total.toFixed(0)}${method === 'efectivo' ? `\nVuelto: $${change.toFixed(0)}` : ''}`);
+      Alert.alert(
+        'Venta registrada',
+        `Total: $${total.toFixed(0)}${method === 'efectivo' ? `\nVuelto: $${change.toFixed(0)}` : ''}`
+      );
       clear();
-      setAmountPaid('');
       onSold && onSold();
     } catch (e) {
+      console.warn('pay error', e);
       Alert.alert('Error', 'No se pudo registrar la venta.');
     }
-  };
+  }, [amountPaid, canPay, cart, change, clear, method, onSold, total, transferProof]);
+
+  const renderItem = useCallback(
+    ({ item }) => (
+      <View style={[styles.item, isCompact && styles.itemCompact]}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.itemTitle}>{item.name || item.barcode}</Text>
+          <Text style={styles.itemSub}>{item.barcode}</Text>
+        </View>
+        <Text style={styles.itemPrice}>${Number(item.unit_price).toFixed(0)}</Text>
+        <View style={styles.qtyBox}>
+          <TouchableOpacity style={styles.qtyBtn} onPress={() => dec(item.barcode)}>
+            <Text style={styles.qtyTxt}>−</Text>
+          </TouchableOpacity>
+          <Text style={styles.qtyVal}>{item.sold_by_weight ? `${Number(item.qty).toFixed(2)}kg` : item.qty}</Text>
+          <TouchableOpacity style={styles.qtyBtn} onPress={() => inc(item.barcode)}>
+            <Text style={styles.qtyTxt}>＋</Text>
+          </TouchableOpacity>
+        </View>
+        <TouchableOpacity onPress={() => removeItem(item.barcode)}>
+          <Text style={{ color: theme.colors.danger, marginLeft: 8 }}>Eliminar</Text>
+        </TouchableOpacity>
+      </View>
+    ),
+    [dec, inc, isCompact, removeItem]
+  );
 
   return (
     <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.select({ ios: 'padding', android: undefined })}>
-      <View style={{ paddingHorizontal: 16, paddingTop: 12, flex: 1 }}>
+      <View style={{ paddingHorizontal: isCompact ? 12 : 16, paddingTop: 12, flex: 1 }}>
         {/* Entrada rápida */}
-        <View style={styles.row}>
-          <TouchableOpacity style={styles.primaryBtn} onPress={() => setScannerOpen(true)}>
+        <View style={[styles.row, isCompact && styles.rowWrap]}>
+          <TouchableOpacity style={[styles.primaryBtn, isCompact && styles.primaryBtnCompact]} onPress={() => setScannerOpen(true)}>
             <Text style={styles.primaryBtnText}>📷 Escanear</Text>
           </TouchableOpacity>
           <TextInput
@@ -102,7 +298,9 @@ export default function SellScreen({ onClose, onSold }) {
             keyboardType="numeric"
             returnKeyType="done"
           />
-          <TouchableOpacity style={styles.ghostBtn} onPress={addManual}><Text style={styles.ghostBtnText}>Agregar</Text></TouchableOpacity>
+          <TouchableOpacity style={[styles.ghostBtn, styles.ghostBtnCompact]} onPress={addManual}>
+            <Text style={styles.ghostBtnText}>Agregar</Text>
+          </TouchableOpacity>
         </View>
 
         {/* Lista de ítems */}
@@ -110,21 +308,7 @@ export default function SellScreen({ onClose, onSold }) {
           data={cart}
           keyExtractor={(it) => String(it.barcode)}
           contentContainerStyle={{ paddingVertical: 8 }}
-          renderItem={({ item }) => (
-            <View style={styles.item}>
-              <View style={{ flex: 1 }}>
-                <Text style={styles.itemTitle}>{item.name || item.barcode}</Text>
-                <Text style={styles.itemSub}>{item.barcode}</Text>
-              </View>
-              <Text style={styles.itemPrice}>${Number(item.unit_price).toFixed(0)}</Text>
-              <View style={styles.qtyBox}>
-                <TouchableOpacity style={styles.qtyBtn} onPress={() => dec(item.barcode)}><Text style={styles.qtyTxt}>−</Text></TouchableOpacity>
-                <Text style={styles.qtyVal}>{item.sold_by_weight ? `${Number(item.qty).toFixed(2)}kg` : item.qty}</Text>
-                <TouchableOpacity style={styles.qtyBtn} onPress={() => inc(item.barcode)}><Text style={styles.qtyTxt}>＋</Text></TouchableOpacity>
-              </View>
-              <TouchableOpacity onPress={() => removeItem(item.barcode)}><Text style={{ color: theme.colors.danger, marginLeft: 8 }}>Eliminar</Text></TouchableOpacity>
-            </View>
-          )}
+          renderItem={renderItem}
           ListEmptyComponent={<Text style={{ color: '#888', marginTop: 10 }}>Escanea o agrega productos…</Text>}
         />
 
@@ -133,8 +317,8 @@ export default function SellScreen({ onClose, onSold }) {
           <Text style={styles.total}>Total: ${total.toFixed(0)}</Text>
 
           <Text style={styles.label}>Método de pago</Text>
-          <View style={styles.pills}>
-            {PMETHODS.map(m => {
+          <View style={[styles.pills, isCompact && { flexWrap: 'wrap' }]}>
+            {PMETHODS.map((m) => {
               const active = method === m;
               return (
                 <TouchableOpacity key={m} style={[styles.pill, active && styles.pillOn]} onPress={() => setMethod(m)}>
@@ -147,13 +331,66 @@ export default function SellScreen({ onClose, onSold }) {
           {method === 'efectivo' && (
             <>
               <Text style={styles.label}>Monto recibido</Text>
-              <TextInput style={styles.input} placeholder="0" keyboardType="numeric" value={String(amountPaid)} onChangeText={setAmountPaid} />
-              <View style={[styles.alertBox, Number(amountPaid || 0) < total ? { backgroundColor: theme.colors.dangerBg, borderColor: '#f4b4bf' } : { backgroundColor: theme.colors.successBg, borderColor: '#bfe8d3' }]}>
+              <TextInput
+                style={styles.input}
+                placeholder="0"
+                keyboardType="numeric"
+                value={String(amountPaid)}
+                onChangeText={setAmountPaid}
+              />
+              <View
+                style={[
+                  styles.alertBox,
+                  Number(amountPaid || 0) < total
+                    ? { backgroundColor: theme.colors.dangerBg, borderColor: '#f4b4bf' }
+                    : { backgroundColor: theme.colors.successBg, borderColor: '#bfe8d3' },
+                ]}
+              >
                 <Text style={{ fontWeight: '600' }}>
                   {Number(amountPaid || 0) < total ? 'Monto insuficiente' : `Vuelto: $${change.toFixed(0)}`}
                 </Text>
               </View>
             </>
+          )}
+
+          {method === 'transferencia' && (
+            <View style={styles.proofContainer}>
+              <Text style={[styles.label, { marginBottom: 6 }]}>Comprobante de transferencia</Text>
+              {transferProof ? (
+                <View style={styles.proofPreview}>
+                  {transferProof.kind === 'image' ? (
+                    <TouchableOpacity onPress={() => setPreviewUri(transferProof.uri)}>
+                      <Image source={{ uri: transferProof.uri }} style={styles.proofThumb} />
+                    </TouchableOpacity>
+                  ) : (
+                    <View style={styles.proofThumbPlaceholder}>
+                      <Text style={{ fontSize: 18 }}>📄</Text>
+                    </View>
+                  )}
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.proofName} numberOfLines={2}>
+                      {transferProof.name}
+                    </Text>
+                    <TouchableOpacity onPress={() => setTransferProof(null)}>
+                      <Text style={styles.proofRemove}>Eliminar</Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              ) : (
+                <Text style={styles.proofHint}>Adjunta una foto o archivo del comprobante para dejar respaldo.</Text>
+              )}
+              <View style={[styles.row, styles.rowWrap, { marginTop: 8 }]}>
+                <TouchableOpacity style={[styles.ghostBtn, styles.ghostBtnCompact]} onPress={attachProofFromCamera}>
+                  <Text style={styles.ghostBtnText}>Usar cámara</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={[styles.ghostBtn, styles.ghostBtnCompact]} onPress={attachProofFromLibrary}>
+                  <Text style={styles.ghostBtnText}>Galería</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={[styles.ghostBtn, styles.ghostBtnCompact]} onPress={attachProofFromFile}>
+                  <Text style={styles.ghostBtnText}>Archivo</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
           )}
 
           <TouchableOpacity disabled={!canPay} style={[styles.payBtn, !canPay && { opacity: 0.6 }]} onPress={pay}>
@@ -164,10 +401,7 @@ export default function SellScreen({ onClose, onSold }) {
 
       {/* Scanner */}
       {scannerOpen && (
-        <ScannerScreen
-          onClose={() => setScannerOpen(false)}
-          onScanned={scanDone}
-        />
+        <ScannerScreen onClose={() => setScannerOpen(false)} onScanned={scanDone} />
       )}
 
       {weightProd && (
@@ -176,61 +410,201 @@ export default function SellScreen({ onClose, onSold }) {
             <View style={styles.modalBox}>
               <Text style={{ fontWeight: '700', marginBottom: 8 }}>{weightProd.name || weightProd.barcode}</Text>
               <Text style={styles.label}>Cantidad en kg</Text>
-              <TextInput style={styles.input} placeholder="0" keyboardType="numeric" value={weightQty} onChangeText={setWeightQty} />
+              <TextInput
+                style={styles.input}
+                placeholder="0"
+                keyboardType="numeric"
+                value={weightQty}
+                onChangeText={setWeightQty}
+              />
               <View style={{ flexDirection: 'row', gap: 8, marginTop: 12 }}>
-                <TouchableOpacity style={[styles.ghostBtn, { flex: 1 }]} onPress={() => { setWeightProd(null); setWeightQty(''); }}><Text style={styles.ghostBtnText}>Cancelar</Text></TouchableOpacity>
-                <TouchableOpacity style={[styles.primaryBtn, { flex: 1 }]} onPress={() => {
-                  const q = Number(weightQty || 0);
-                  if (!q) return;
-                  setCart(prev => {
-                    const i = prev.findIndex(x => x.barcode === weightProd.barcode);
-                    if (i >= 0) {
-                      const next = [...prev];
-                      next[i] = { ...next[i], qty: Number(next[i].qty || 0) + q, unit_price: weightProd.sale_price ?? next[i].unit_price };
-                      return next;
-                    }
-                    return [...prev, { barcode: weightProd.barcode, name: weightProd.name || '', unit_price: Number(weightProd.sale_price || 0), qty: q, sold_by_weight: 1 }];
-                  });
-                  setWeightProd(null); setWeightQty('');
-                }}><Text style={styles.primaryBtnText}>Agregar</Text></TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.ghostBtn, { flex: 1 }]}
+                  onPress={() => {
+                    setWeightProd(null);
+                    setWeightQty('');
+                  }}
+                >
+                  <Text style={styles.ghostBtnText}>Cancelar</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.primaryBtn, { flex: 1 }]}
+                  onPress={() => {
+                    const q = Number(weightQty || 0);
+                    if (!q) return;
+                    setCart((prev) => {
+                      const i = prev.findIndex((x) => x.barcode === weightProd.barcode);
+                      if (i >= 0) {
+                        const next = [...prev];
+                        next[i] = {
+                          ...next[i],
+                          qty: Number(next[i].qty || 0) + q,
+                          unit_price: weightProd.sale_price ?? next[i].unit_price,
+                        };
+                        return next;
+                      }
+                      return [
+                        ...prev,
+                        {
+                          barcode: weightProd.barcode,
+                          name: weightProd.name || '',
+                          unit_price: Number(weightProd.sale_price || 0),
+                          qty: q,
+                          sold_by_weight: 1,
+                        },
+                      ];
+                    });
+                    setWeightProd(null);
+                    setWeightQty('');
+                  }}
+                >
+                  <Text style={styles.primaryBtnText}>Agregar</Text>
+                </TouchableOpacity>
               </View>
             </View>
           </View>
         </Modal>
       )}
+
+      <Modal visible={!!previewUri} transparent animationType="fade" onRequestClose={() => setPreviewUri(null)}>
+        <View style={styles.previewBg}>
+          <TouchableOpacity style={{ flex: 1 }} activeOpacity={1} onPress={() => setPreviewUri(null)}>
+            {previewUri && <Image source={{ uri: previewUri }} style={styles.previewImage} resizeMode="contain" />}
+          </TouchableOpacity>
+        </View>
+      </Modal>
     </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  row: { flexDirection: 'row', gap: 8, alignItems: 'center' },
-  input: { borderWidth: 1, borderColor: '#e6e6e6', borderRadius: 12, padding: Platform.OS === 'ios' ? 12 : 10, backgroundColor: '#fff' },
-  primaryBtn: { backgroundColor: '#111', borderRadius: 12, paddingVertical: 12, paddingHorizontal: 14 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  rowWrap: { flexWrap: 'wrap' },
+  primaryBtn: {
+    borderRadius: 12,
+    backgroundColor: theme.colors.primary,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  primaryBtnCompact: { flexGrow: 1 },
   primaryBtnText: { color: '#fff', fontWeight: '700' },
-  ghostBtn: { borderWidth: 1, borderColor: '#e6e6e6', borderRadius: 12, paddingVertical: 12, paddingHorizontal: 14, backgroundColor: '#fff' },
-  ghostBtnText: { color: '#333', fontWeight: '700' },
-
-  item: { flexDirection: 'row', alignItems: 'center', paddingVertical: 10, borderBottomWidth: 1, borderColor: '#eee' },
+  ghostBtn: {
+    borderWidth: 1,
+    borderColor: '#d8e7ff',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: '#eef6ff',
+  },
+  ghostBtnCompact: { alignSelf: 'stretch' },
+  ghostBtnText: { color: theme.colors.primary, fontWeight: '600' },
+  input: {
+    borderWidth: 1,
+    borderColor: '#e6e6e6',
+    borderRadius: 12,
+    padding: Platform.OS === 'ios' ? 12 : 10,
+    backgroundColor: '#fff',
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+    gap: 8,
+  },
+  itemCompact: { flexWrap: 'wrap' },
   itemTitle: { fontWeight: '700' },
   itemSub: { color: '#666' },
-  itemPrice: { width: 70, textAlign: 'right', fontWeight: '700' },
-  qtyBox: { flexDirection: 'row', alignItems: 'center', marginLeft: 8 },
-  qtyBtn: { borderWidth: 1, borderColor: '#ddd', borderRadius: 10, paddingHorizontal: 8, paddingVertical: 4, backgroundColor: '#fff' },
-  qtyTxt: { fontWeight: '800', fontSize: 16 },
-  qtyVal: { width: 60, textAlign: 'center', fontWeight: '700' },
-
-  box: { marginTop: 12, borderWidth: 1, borderColor: '#eee', borderRadius: 12, backgroundColor: '#fff', padding: 12 },
-  total: { fontSize: 16, fontWeight: '800', marginBottom: 8 },
-  label: { fontSize: 12, color: '#666', marginTop: 8, marginBottom: 6 },
-  pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  pill: { borderWidth: 1, borderColor: '#ddd', borderRadius: 999, paddingHorizontal: 12, paddingVertical: 6, backgroundColor: '#fff' },
+  itemPrice: { fontWeight: '600', marginHorizontal: 4 },
+  qtyBox: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  qtyBtn: {
+    borderWidth: 1,
+    borderColor: '#d8e7ff',
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    backgroundColor: '#eef6ff',
+  },
+  qtyTxt: { fontSize: 16, fontWeight: '700', color: theme.colors.primary },
+  qtyVal: { minWidth: 40, textAlign: 'center', fontWeight: '600' },
+  box: {
+    borderWidth: 1,
+    borderColor: '#eee',
+    borderRadius: 16,
+    padding: 16,
+    backgroundColor: '#fff',
+    marginTop: 6,
+    gap: 10,
+  },
+  total: { fontSize: 20, fontWeight: '800' },
+  label: { fontSize: 12, color: '#666' },
+  pills: { flexDirection: 'row', gap: 8 },
+  pill: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: '#fff',
+  },
   pillOn: { backgroundColor: '#111', borderColor: '#111' },
-  pillTxt: { color: '#333', fontWeight: '700' },
-
-  alertBox: { marginTop: 8, borderWidth: 1, borderRadius: 10, padding: 10 },
-
-  payBtn: { marginTop: 12, backgroundColor: '#111', borderRadius: 12, padding: 14, alignItems: 'center' },
-  payBtnTxt: { color: '#fff', fontWeight: '800' },
-  modalBg: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center', padding: 20 },
-  modalBox: { backgroundColor: '#fff', borderRadius: 12, padding: 16, width: '100%' },
+  pillTxt: { fontWeight: '600', textTransform: 'capitalize' },
+  alertBox: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+  },
+  payBtn: {
+    borderRadius: 14,
+    paddingVertical: 14,
+    alignItems: 'center',
+    backgroundColor: theme.colors.primary,
+  },
+  payBtnTxt: { color: '#fff', fontWeight: '800', fontSize: 16 },
+  modalBg: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  modalBox: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 18,
+    width: '100%',
+  },
+  proofContainer: {
+    borderWidth: 1,
+    borderColor: '#f0f0f0',
+    borderRadius: 12,
+    padding: 12,
+    backgroundColor: '#fafafa',
+  },
+  proofPreview: {
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'center',
+  },
+  proofThumb: { width: 54, height: 54, borderRadius: 12 },
+  proofThumbPlaceholder: {
+    width: 54,
+    height: 54,
+    borderRadius: 12,
+    backgroundColor: '#eef1ff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  proofName: { fontWeight: '600', color: '#333' },
+  proofHint: { color: '#666' },
+  proofRemove: { color: theme.colors.danger, marginTop: 4 },
+  previewBg: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.8)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  previewImage: { width: '100%', height: '100%' },
 });

--- a/src/ui/ProductPhotoEditor.js
+++ b/src/ui/ProductPhotoEditor.js
@@ -1,0 +1,150 @@
+// src/ui/ProductPhotoEditor.js
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet, Image, Alert, useWindowDimensions } from 'react-native';
+import ViewShot from 'react-native-view-shot';
+import Slider from '@react-native-community/slider';
+import { theme } from './Theme';
+
+export default function ProductPhotoEditor({ visible, sourceUri, onCancel, onSave }) {
+  const captureRef = useRef(null);
+  const { width } = useWindowDimensions();
+  const canvasSize = Math.min(width - 48, 320);
+
+  const [scale, setScale] = useState(1.05);
+  const [offsetX, setOffsetX] = useState(0);
+  const [offsetY, setOffsetY] = useState(0);
+
+  useEffect(() => {
+    if (visible) {
+      setScale(1.05);
+      setOffsetX(0);
+      setOffsetY(0);
+    }
+  }, [visible, sourceUri]);
+
+  const handleSave = async () => {
+    if (!captureRef.current) return;
+    try {
+      const uri = await captureRef.current.capture?.();
+      if (uri && onSave) {
+        onSave(uri);
+      }
+    } catch (e) {
+      console.warn('ProductPhotoEditor capture error', e);
+      Alert.alert('Error', 'No se pudo procesar la imagen.');
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onCancel}>
+      <View style={styles.modalBg}>
+        <View style={[styles.modalBox, { width: canvasSize + 40 }]}>
+          <Text style={styles.title}>Editar foto</Text>
+          <Text style={styles.subtitle}>Ajusta el zoom y posición para dejar un fondo blanco limpio.</Text>
+
+          {sourceUri ? (
+            <ViewShot
+              ref={captureRef}
+              options={{ format: 'png', quality: 1, result: 'tmpfile' }}
+              style={[styles.canvas, { width: canvasSize, height: canvasSize }]}
+            >
+              <View style={[styles.canvasInner, { width: canvasSize, height: canvasSize }]}>
+                <Image
+                  source={{ uri: sourceUri }}
+                  style={{ width: canvasSize, height: canvasSize, transform: [{ scale }, { translateX: offsetX }, { translateY: offsetY }] }}
+                  resizeMode="contain"
+                />
+              </View>
+            </ViewShot>
+          ) : (
+            <View style={[styles.canvas, { width: canvasSize, height: canvasSize, alignItems: 'center', justifyContent: 'center' }]}>
+              <Text style={{ color: '#999' }}>Sin imagen seleccionada</Text>
+            </View>
+          )}
+
+          <View style={styles.sliderBlock}>
+            <Text style={styles.sliderLabel}>Zoom</Text>
+            <Slider
+              value={scale}
+              onValueChange={setScale}
+              minimumValue={0.6}
+              maximumValue={2.4}
+              minimumTrackTintColor={theme.colors.primary}
+              maximumTrackTintColor="#ddd"
+            />
+          </View>
+          <View style={styles.sliderBlock}>
+            <Text style={styles.sliderLabel}>Posición horizontal</Text>
+            <Slider
+              value={offsetX}
+              onValueChange={setOffsetX}
+              minimumValue={-canvasSize / 4}
+              maximumValue={canvasSize / 4}
+              minimumTrackTintColor={theme.colors.primary}
+              maximumTrackTintColor="#ddd"
+            />
+          </View>
+          <View style={styles.sliderBlock}>
+            <Text style={styles.sliderLabel}>Posición vertical</Text>
+            <Slider
+              value={offsetY}
+              onValueChange={setOffsetY}
+              minimumValue={-canvasSize / 4}
+              maximumValue={canvasSize / 4}
+              minimumTrackTintColor={theme.colors.primary}
+              maximumTrackTintColor="#ddd"
+            />
+          </View>
+
+          <View style={styles.actions}>
+            <TouchableOpacity style={[styles.actionBtn, styles.actionGhost]} onPress={onCancel}>
+              <Text style={[styles.actionTxt, { color: '#333' }]}>Cancelar</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.actionBtn, styles.actionPrimary]} onPress={handleSave}>
+              <Text style={[styles.actionTxt, { color: '#fff' }]}>Guardar</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalBg: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  modalBox: {
+    backgroundColor: '#fff',
+    borderRadius: 20,
+    padding: 18,
+    gap: 14,
+  },
+  title: { fontSize: 18, fontWeight: '700' },
+  subtitle: { color: '#666' },
+  canvas: {
+    borderRadius: 16,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#eee',
+    overflow: 'hidden',
+    alignSelf: 'center',
+  },
+  canvasInner: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sliderBlock: { marginTop: 4 },
+  sliderLabel: { fontSize: 12, color: '#555', marginBottom: -6 },
+  actions: { flexDirection: 'row', gap: 10, marginTop: 8 },
+  actionBtn: { flex: 1, paddingVertical: 12, borderRadius: 12, alignItems: 'center' },
+  actionGhost: { borderWidth: 1, borderColor: '#ddd', backgroundColor: '#fff' },
+  actionPrimary: { backgroundColor: theme.colors.primary },
+  actionTxt: { fontWeight: '700' },
+});

--- a/src/ui/TopTabs.js
+++ b/src/ui/TopTabs.js
@@ -19,7 +19,7 @@ export default function TopTabs({ tabs, current, onChange }) {
 }
 
 const styles = StyleSheet.create({
-  wrap: { flexDirection: 'row', gap: 8, backgroundColor: '#fff', paddingHorizontal: 8, paddingVertical: 8, borderBottomWidth: 1, borderColor: theme.colors.divider },
+  wrap: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, backgroundColor: '#fff', paddingHorizontal: 8, paddingVertical: 8, borderBottomWidth: 1, borderColor: theme.colors.divider },
   tab: { flex: 1, borderWidth: 1, borderColor: theme.colors.divider, backgroundColor: '#fff', borderRadius: 999, paddingVertical: 8, alignItems: 'center' },
   tabActive: { backgroundColor: theme.colors.tabActive, borderColor: theme.colors.tabActive },
   tabText: { color: theme.colors.tabInactive, fontWeight: '700' },

--- a/src/utils/media.js
+++ b/src/utils/media.js
@@ -1,0 +1,61 @@
+// src/utils/media.js
+import * as FileSystem from 'expo-file-system';
+
+async function ensureDirAsync(dir) {
+  try {
+    const info = await FileSystem.getInfoAsync(dir);
+    if (!info.exists) {
+      await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
+    }
+  } catch (e) {
+    console.warn('ensureDirAsync error', e);
+  }
+}
+
+function extractExtension(uri) {
+  if (!uri) return null;
+  const cleanUri = uri.split('?')[0];
+  const parts = cleanUri.split('.');
+  if (parts.length > 1) {
+    return parts.pop()?.trim().toLowerCase() || null;
+  }
+  return null;
+}
+
+export function getFileDisplayName(uri) {
+  if (!uri) return '';
+  try {
+    const cleanUri = uri.split('?')[0];
+    const parts = cleanUri.split('/');
+    return decodeURIComponent(parts.pop() || '');
+  } catch {
+    return uri;
+  }
+}
+
+export async function copyFileToDocuments(uri, { folder = 'media', prefix = 'asset', extension } = {}) {
+  if (!uri) return null;
+  const baseDir = FileSystem.documentDirectory || FileSystem.cacheDirectory;
+  if (!baseDir) throw new Error('No storage directory available');
+
+  const dir = `${baseDir}${folder}/`;
+  await ensureDirAsync(dir);
+
+  const ext = (extension || extractExtension(uri) || 'dat').replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext || 'dat'}`;
+  const dest = `${dir}${name}`;
+
+  try {
+    await FileSystem.copyAsync({ from: uri, to: dest });
+    return dest;
+  } catch (err) {
+    console.warn('copyAsync failed, trying downloadAsync', err);
+    try {
+      const res = await FileSystem.downloadAsync(uri, dest);
+      return res.uri;
+    } catch (err2) {
+      console.error('downloadAsync failed', err2);
+      throw err2;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make the sales tab the default view and add responsive tweaks plus auto-sync deferral for lighter start-up
- enhance the sales flow with missing-product prompts, transfer receipt attachments and responsive UI updates
- allow capturing and editing product photos with a new white-background editor and persist product/transfer media in the database
- redesign the dashboard into an interactive line chart with key stats and show transfer receipts in history details

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d176262650832c8e954e6424933951