### PR TITLE
Fix hook order during initialization

### DIFF
--- a/App.js
+++ b/App.js
@@ -154,12 +154,12 @@ export default function App() {
       console.log('🔄 Iniciando sincronización manual...');
       await syncNow();
       await refresh();
-      
+
       console.log('🔄 Sincronización completada, refrescando reportes...');
-      
+
       // Forzar refresco de reportes incrementando timestamp
       setLastSyncTime(Date.now());
-      
+
       Alert.alert('Sync', 'Sincronización completa.');
     } catch (e) {
       console.error('❌ Error en sincronización manual:', e);
@@ -168,14 +168,6 @@ export default function App() {
       setIsSyncLoading(false);
     }
   }, [refresh]);
-
-  if (!ready) {
-    return (
-      <SafeAreaView style={styles.center}>
-        <Text>Inicializando base de datos...</Text>
-      </SafeAreaView>
-    );
-  }
 
   const handleOpenNewProductFromSale = useCallback((barcode) => {
     setSaleRequestedBarcode(String(barcode));
@@ -212,6 +204,14 @@ export default function App() {
       </View>
     );
   }, [isCompact, onDelete, onEdit]);
+
+  if (!ready) {
+    return (
+      <SafeAreaView style={styles.center}>
+        <Text>Inicializando base de datos...</Text>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: theme.colors.bg }]}>


### PR DESCRIPTION
## Summary
- ensure all hooks in App run on every render by moving callback declarations above the early return
- keep the loading screen behavior unchanged while preventing hook order violations that crashed the app during database init

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d195e58b1c832cae91e7a7a2ceb219